### PR TITLE
Fix/remove fallback bool

### DIFF
--- a/src/Jarvis.Addin.Files/FileProvider.cs
+++ b/src/Jarvis.Addin.Files/FileProvider.cs
@@ -33,21 +33,21 @@ namespace Jarvis.Addin.Files
             _loader = loader;
         }
 
-        protected override async Task<ImageSource> GetIcon(FileResult result)
+        protected override async Task<ImageSource> GetIconAsync(FileResult result)
         {
             return await _loader.LoadAsync(result);
         }
 
-        public override async Task<IEnumerable<IQueryResult>> Query(Query query, bool fallback)
+        public override async Task<IEnumerable<IQueryResult>> QueryAsync(Query query)
         {
-            if (query.Raw?.Length <= 1 || fallback)
+            if (query.Raw?.Length <= 1)
             {
                 return Enumerable.Empty<IQueryResult>();
             }
             return await _index.Find(query.Raw?.Trim(), CancellationToken.None).ConfigureAwait(false);
         }
 
-        protected override Task Execute(FileResult result)
+        protected override Task ExecuteAsync(FileResult result)
         {
             if (result.Path != null)
             {

--- a/src/Jarvis.Addin.Google/GoogleResult.cs
+++ b/src/Jarvis.Addin.Google/GoogleResult.cs
@@ -59,7 +59,7 @@ namespace Jarvis.Addin.Google
             description = description ?? term;
 
             var isGoogleQuery = !(term.StartsWith("http://") || term.StartsWith("https://"));
-            var uri = isGoogleQuery ? new Uri($"https://www.google.se/search?q={WebUtility.UrlEncode(term)}") : new Uri(term);
+            var uri = isGoogleQuery ? new Uri($"https://www.google.com/search?q={WebUtility.UrlEncode(term)}") : new Uri(term);
             return new GoogleResult(uri, isGoogleQuery, description, uri.AbsoluteUri,
                 isGoogleQuery ? LevenshteinScorer.Score(term, query.Argument, false) : 0,
                 isGoogleQuery ? LevenshteinScorer.Score(term, query.Argument) : 0);

--- a/src/Jarvis.Core/IQueryProvider.cs
+++ b/src/Jarvis.Core/IQueryProvider.cs
@@ -13,8 +13,8 @@ namespace Jarvis.Core
     {
         string Command { get; }
         Type QueryType { get; }
-        Task<ImageSource> GetIcon(IQueryResult result);
-        Task<IEnumerable<IQueryResult>> Query(Query query, bool fallback);
-        Task Execute(IQueryResult result);
+        Task<ImageSource> GetIconAsync(IQueryResult result);
+        Task<IEnumerable<IQueryResult>> QueryAsync(Query query);
+        Task ExecuteAsync(IQueryResult result);
     }
 }

--- a/src/Jarvis.Core/QueryProvider.cs
+++ b/src/Jarvis.Core/QueryProvider.cs
@@ -15,19 +15,19 @@ namespace Jarvis.Core
         public virtual string Command => null;
         Type IQueryProvider.QueryType => typeof(T);
 
-        Task<ImageSource> IQueryProvider.GetIcon(IQueryResult result)
+        Task<ImageSource> IQueryProvider.GetIconAsync(IQueryResult result)
         {
-            return GetIcon((T)result);
+            return GetIconAsync((T)result);
         }
 
-        Task IQueryProvider.Execute(IQueryResult result)
+        Task IQueryProvider.ExecuteAsync(IQueryResult result)
         {
-            return Execute((T)result);
+            return ExecuteAsync((T)result);
         }
 
-        protected abstract Task<ImageSource> GetIcon(T result);
-        protected abstract Task Execute(T result);
+        protected abstract Task<ImageSource> GetIconAsync(T result);
+        protected abstract Task ExecuteAsync(T result);
 
-        public abstract Task<IEnumerable<IQueryResult>> Query(Query query, bool fallback);
+        public abstract Task<IEnumerable<IQueryResult>> QueryAsync(Query query);
     }
 }

--- a/src/Jarvis/Services/QueryProviderService.cs
+++ b/src/Jarvis/Services/QueryProviderService.cs
@@ -30,7 +30,7 @@ namespace Jarvis.Services
         {
             if (_providers.TryGetValue(result.GetType(), out var provider))
             {
-                return await provider.GetIcon(result);
+                return await provider.GetIconAsync(result);
             }
             return null;
         }
@@ -41,11 +41,7 @@ namespace Jarvis.Services
             var providers = GetProviders(query);
             var tasks = providers.Select(async provider =>
             {
-                var result = (await provider.Query(query, false)).ToArray();
-                if (result.Length == 0)
-                {
-                    result = (await provider.Query(query, true)).ToArray();
-                }
+                var result = (await provider.QueryAsync(query)).ToArray();
 
                 // Remove items.
                 for (var i = target.Count - 1; i >= 0; i--)
@@ -83,7 +79,7 @@ namespace Jarvis.Services
         {
             if (_providers.TryGetValue(result.GetType(), out var provider))
             {
-                await provider.Execute(result);
+                await provider.ExecuteAsync(result);
             }
         }
 


### PR DESCRIPTION
This PR fixes #21 and its additional comments by:

* Removing the `fallback` argument and let providers provide fallback when applicable
* Add `Async` suffix to all async methods in `IQueryProvider`

It also fixes two minor issues:

* Use google.com (not google.se)
* Avoid possible `NullPointerException` by returning empty enumerable if the provider throws an exception during its execution.