### PR TITLE
Load sources in parallel

### DIFF
--- a/installer/wix/Jarvis.wxs
+++ b/installer/wix/Jarvis.wxs
@@ -83,12 +83,6 @@
             <Component Id="Microsoft.Threading.Tasks.Extensions.dll" Guid="8475143C-877E-4DF5-8D50-B6276817C1DB">
                 <File Id="Microsoft.Threading.Tasks.Extensions.dll" Source="$(var.PublishDirectory)\Microsoft.Threading.Tasks.Extensions.dll" KeyPath="yes" Checksum="yes" />
             </Component>
-            <Component Id="Nito.AsyncEx.dll" Guid="B27845EE-56BF-4463-A95C-1C91D95FC163">
-                <File Id="Nito.AsyncEx.dll" Source="$(var.PublishDirectory)\Nito.AsyncEx.dll" KeyPath="yes" Checksum="yes" />
-            </Component>
-            <Component Id="Nito.AsyncEx.Enlightenment.dll" Guid="9305DC51-2DA3-418C-9FF6-3C469E80C868">
-                <File Id="Nito.AsyncEx.Enlightenment.dll" Source="$(var.PublishDirectory)\Nito.AsyncEx.Enlightenment.dll" KeyPath="yes" Checksum="yes" />
-            </Component>
             <Component Id="Serilog.dll" Guid="AB8EA697-03B4-46D6-ADCC-9B4FA51B4E6E">
                 <File Id="Serilog.dll" Source="$(var.PublishDirectory)\Serilog.dll" KeyPath="yes" Checksum="yes" />
             </Component>
@@ -120,8 +114,6 @@
             <ComponentRef Id="Microsoft.Threading.Tasks.dll" />
             <ComponentRef Id="Microsoft.Threading.Tasks.Extensions.Desktop.dll" />
             <ComponentRef Id="Microsoft.Threading.Tasks.Extensions.dll" />
-            <ComponentRef Id="Nito.AsyncEx.dll" />
-            <ComponentRef Id="Nito.AsyncEx.Enlightenment.dll" />
             <ComponentRef Id="Serilog.dll" />
             <ComponentRef Id="Serilog.Sinks.File.dll" />
             <ComponentRef Id="Spectre.System.dll" />

--- a/src/Jarvis.Addin.Files/Indexing/FileIndexer.cs
+++ b/src/Jarvis.Addin.Files/Indexing/FileIndexer.cs
@@ -4,9 +4,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Jarvis.Addin.Files.Collections;
 using Jarvis.Core;
 using Jarvis.Core.Diagnostics;
@@ -46,6 +48,9 @@ namespace Jarvis.Addin.Files.Indexing
         {
             while (true)
             {
+                var st = new Stopwatch();
+                st.Start();
+
                 // Ask all sources for files.
                 var result = new HashSet<IndexedEntry>();
                 foreach (var source in _sources)
@@ -100,7 +105,8 @@ namespace Jarvis.Addin.Files.Indexing
                 _log.Verbose($"Items: {_trie.ItemCount}");
 
                 // Wait for a minute.
-                _log.Debug("Indexing done.");
+                st.Stop();
+                _log.Debug($"Indexing done. Took {st.ElapsedMilliseconds}ms");
                 if (token.WaitHandle.WaitOne((int)TimeSpan.FromMinutes(5).TotalMilliseconds))
                 {
                     _log.Information("We were instructed to stop (2).");

--- a/src/Jarvis.Addin.Files/Indexing/FileIndexer.cs
+++ b/src/Jarvis.Addin.Files/Indexing/FileIndexer.cs
@@ -53,7 +53,7 @@ namespace Jarvis.Addin.Files.Indexing
                 var result = new HashSet<IndexedEntry>();
                 foreach (var source in _sources)
                 {
-                    if (token.WaitHandle.WaitOne((int)TimeSpan.FromMinutes(0).TotalMilliseconds))
+                    if (token.IsCancellationRequested)
                     {
                         _log.Information("We were instructed to stop (1). Aborting indexing...");
                         break;

--- a/src/Jarvis.Addin.Files/Indexing/FileIndexer.cs
+++ b/src/Jarvis.Addin.Files/Indexing/FileIndexer.cs
@@ -8,14 +8,12 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Jarvis.Addin.Files.Collections;
 using Jarvis.Core;
 using Jarvis.Core.Diagnostics;
 using Jarvis.Core.Scoring;
 using Jarvis.Core.Threading;
 using JetBrains.Annotations;
-using Nito.AsyncEx;
 using Spectre.System.IO;
 
 namespace Jarvis.Addin.Files.Indexing

--- a/src/Jarvis.Addin.Files/Jarvis.Addin.Files.csproj
+++ b/src/Jarvis.Addin.Files/Jarvis.Addin.Files.csproj
@@ -48,15 +48,6 @@
     <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
-    <Reference Include="Nito.AsyncEx, Version=4.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nito.AsyncEx.4.0.1\lib\net45\Nito.AsyncEx.dll</HintPath>
-    </Reference>
-    <Reference Include="Nito.AsyncEx.Concurrent, Version=4.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nito.AsyncEx.4.0.1\lib\net45\Nito.AsyncEx.Concurrent.dll</HintPath>
-    </Reference>
-    <Reference Include="Nito.AsyncEx.Enlightenment, Version=4.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nito.AsyncEx.4.0.1\lib\net45\Nito.AsyncEx.Enlightenment.dll</HintPath>
-    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="Spectre.System, Version=0.7.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Jarvis.Addin.Files/packages.config
+++ b/src/Jarvis.Addin.Files/packages.config
@@ -5,6 +5,5 @@
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net47" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net47" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net47" />
-  <package id="Nito.AsyncEx" version="4.0.1" targetFramework="net462" />
   <package id="Spectre.System" version="0.7.0" targetFramework="net47" />
 </packages>


### PR DESCRIPTION
On initial load, populating the sources is done from scratch, which can actually take a non-trivial amount of time. During this time, it seems as if Jarvis is broken (i.e. returns nothing for every query), so we want this to be rull short.

On my quite fast machine, this PR reduces the amount of time to generate the trie from ~7sec to ~4.5sec. Not ideal (it actually takes ~600ms to just generate the trie!) but an improvement! I tried to use Akavache to improve the warm start time, but because IndexedEntry is an abstract class, it was Tricky:tm: to serialize it. It's probably still doable!