### PR TITLE
WIP: Use Rx to throttle query execution

### DIFF
--- a/src/Jarvis/App.config
+++ b/src/Jarvis/App.config
@@ -3,4 +3,12 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/src/Jarvis/Jarvis.csproj
+++ b/src/Jarvis/Jarvis.csproj
@@ -88,7 +88,23 @@
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Reactive.Core, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Core.3.1.1\lib\net46\System.Reactive.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Interfaces.3.1.1\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Linq.3.1.1\lib\net46\System.Reactive.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.PlatformServices.3.1.1\lib\net46\System.Reactive.PlatformServices.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Windows.Threading, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Windows.Threading.3.1.1\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Caliburn.Micro.3.2.0\lib\net45\System.Windows.Interactivity.dll</HintPath>

--- a/src/Jarvis/packages.config
+++ b/src/Jarvis/packages.config
@@ -13,4 +13,10 @@
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net47" />
   <package id="Spectre.System" version="0.7.0" targetFramework="net47" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net47" developmentDependency="true" />
+  <package id="System.Reactive" version="3.1.1" targetFramework="net47" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net47" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net47" />
+  <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net47" />
+  <package id="System.Reactive.PlatformServices" version="3.1.1" targetFramework="net47" />
+  <package id="System.Reactive.Windows.Threading" version="3.1.1" targetFramework="net47" />
 </packages>


### PR DESCRIPTION
As I mentioned in #25, one way to decrease the number of executed-but-not-used queries is to introduce a debounce/throttle on the events triggered from the UI to the underlying `QueryProviderService`. The more I thought about this, the more it made senses:

* Some resources, like [Spotify's Web API](https://stackoverflow.com/questions/30548073/spotify-web-api-rate-limits) are rate limited. Even with a cancellation token in place requests might be sent out before the task is cancelled
* The throttle timespan can be so short that the user doesn't notice it, but still long enough to hinder stale queries to execute

That being said, I really think Jarvis should make use of `CancellationToken` to abort old queries.

This PR is a work in progress where I've implemented a 100 ms throttle for `ExecuteQuery`. When I run this branch, the wiki provider feels quicker and more responsive when typing a lot of text in a rapid succession.

I'm not too familiar with Caliburn and haven't worked with WPF for some years, so I think that the code can be improved - perhaps the view can bind to the observable directly? I found the project [`Caliburn.Micro.Reactive.Extensions`](https://github.com/ibebbs/Caliburn.Micro.Reactive.Extensions) that is an reactive extension for Caliburn - not sure if it can be used here, what do you think?

I think that Jarvis needs some sort of throttle and Rx is a common way to achieve this. What is your take on this?