### PR TITLE
Update query result once per query

### DIFF
--- a/src/Jarvis/Services/QueryProviderService.cs
+++ b/src/Jarvis/Services/QueryProviderService.cs
@@ -35,7 +35,7 @@ namespace Jarvis.Services
             return null;
         }
 
-        public async Task Query(Query query, IList<IQueryResult> target)
+        public async Task<IList<IQueryResult>> Query(Query query)
         {
             // Query all search providers.
             var providers = GetProviders(query);
@@ -46,39 +46,11 @@ namespace Jarvis.Services
 
             await Task.WhenAll(queryTasks);
 
-            var result = queryTasks
+            return queryTasks
                 .Where(t => t.Status == TaskStatus.RanToCompletion)
                 .SelectMany(t => t.Result)
                 .Distinct()
                 .ToList();
-
-            // Remove items.
-            for (var i = target.Count - 1; i >= 0; i--)
-            {
-                var current = target[i];
-                if (!result.Contains(current))
-                {
-                    target.Remove(current);
-                }
-            }
-
-            // Add new items.
-            foreach (var item in result)
-            {
-                if (!target.Contains(item))
-                {
-                    target.Add(item);
-                }
-                else
-                {
-                    // Same item but higher score?
-                    if (Math.Abs(target[target.IndexOf(item)].Score - item.Score) > 0.00001f)
-                    {
-                        target.Remove(item);
-                        target.Add(item);
-                    }
-                }
-            }
         }
 
         public async Task Execute(IQueryResult result)

--- a/src/Jarvis/Services/QueryProviderService.cs
+++ b/src/Jarvis/Services/QueryProviderService.cs
@@ -58,7 +58,7 @@ namespace Jarvis.Services
                 var current = target[i];
                 if (!result.Contains(current))
                 {
-                    target.Remove(target[i]);
+                    target.Remove(current);
                 }
             }
 

--- a/src/Jarvis/ViewModels/ResultViewModel.cs
+++ b/src/Jarvis/ViewModels/ResultViewModel.cs
@@ -44,7 +44,35 @@ namespace Jarvis.ViewModels
                 Items.IsNotifying = false;
 
                 var query = new Query(queryString);
-                await _provider.Query(query, Items).ConfigureAwait(false);
+                var result = await _provider.Query(query).ConfigureAwait(false);
+
+                // Remove items.
+                for (var i = Items.Count - 1; i >= 0; i--)
+                {
+                    var current = Items[i];
+                    if (!result.Contains(current))
+                    {
+                        Items.Remove(current);
+                    }
+                }
+
+                // Add new items.
+                foreach (var item in result)
+                {
+                    if (!Items.Contains(item))
+                    {
+                        Items.Add(item);
+                    }
+                    else
+                    {
+                        // Same item but higher score?
+                        if (Math.Abs(Items[Items.IndexOf(item)].Score - item.Score) > 0.00001f)
+                        {
+                            Items.Remove(item);
+                            Items.Add(item);
+                        }
+                    }
+                }
 
                 Items.IsNotifying = true;
                 SelectedResultIndex = 0;


### PR DESCRIPTION
This PR fixes _one_ aspect of the non thread safe code discussed in #30.  The fix is simply to query all providers on multiple threads and then update the query results once providers task has completed.

However, there still is a theoretical risk of null pointer if two queries execute in parallel and arrive at the list manipulation at the same time. I think this could be solved by implementing support for task cancellation with `CancellationToken` 👍 