### PR TITLE
Fix ClearType for TextBox and TextBlock

### DIFF
--- a/src/Jarvis/Jarvis.csproj
+++ b/src/Jarvis/Jarvis.csproj
@@ -187,6 +187,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Resources\JarvisStyles.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Views\AboutView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/src/Jarvis/JarvisApplication.xaml
+++ b/src/Jarvis/JarvisApplication.xaml
@@ -8,6 +8,7 @@
                 <ResourceDictionary>
                     <local:Bootstrapper x:Key="Bootstrapper" />
                 </ResourceDictionary>
+                <ResourceDictionary Source="Resources/JarvisStyles.xaml" />
                 <ResourceDictionary Source="Views/TaskbarIconView.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/src/Jarvis/Resources/JarvisStyles.xaml
+++ b/src/Jarvis/Resources/JarvisStyles.xaml
@@ -1,0 +1,45 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    
+    <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource {x:Type TextBox}}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type TextBox}">
+                    <Border x:Name="Border"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        Background="{TemplateBinding Background}"
+                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <ScrollViewer x:Name="PART_ContentHost"
+                                                  Focusable="False"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                  HorizontalScrollBarVisibility="Hidden"
+                                                  VerticalScrollBarVisibility="Hidden">
+                            <ScrollViewer.ContentTemplate>
+                                <DataTemplate>
+                                    <ContentPresenter RenderOptions.ClearTypeHint="Enabled" Content="{Binding Path=Content, ElementName=PART_ContentHost}" />
+                                </DataTemplate>
+                            </ScrollViewer.ContentTemplate>
+                        </ScrollViewer>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" TargetName="Border" Value="0.56"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="true">
+                            <Setter Property="BorderBrush" TargetName="Border" Value="#FF7EB4EA"/>
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="true">
+                            <Setter Property="BorderBrush" TargetName="Border" Value="#FF569DE5"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled" />
+    </Style>
+
+</ResourceDictionary>


### PR DESCRIPTION
This issue is caused by `AllowsTransparency="True"`

More info: https://blog.magnusmontin.net/2016/07/07/enabling-cleartype-on-a-textbox-in-a-transparent-wpf-window/

So I've added the `JarvisStyles.xaml` resource dictionary with overridden styles for `TextBox` and `TextBlock` to solve this issue.

**before**

![2018-01-12_21h26_23](https://user-images.githubusercontent.com/658431/34896027-7fa29b50-f7e8-11e7-826a-22b5bb87502a.png)

**after**

![2018-01-12_21h47_26](https://user-images.githubusercontent.com/658431/34896034-873280ce-f7e8-11e7-873d-086df5ed439f.png)

**result before**

![2018-01-12_21h55_26](https://user-images.githubusercontent.com/658431/34896051-95a105c2-f7e8-11e7-9fb8-18e78f0009bf.png)

**after**

![2018-01-12_22h03_38](https://user-images.githubusercontent.com/658431/34896053-98bd2ef2-f7e8-11e7-8878-ff3e3641a711.png)
