### PR TITLE
Fix for main window flickering on startup

### DIFF
--- a/src/Jarvis/Bootstrapper.cs
+++ b/src/Jarvis/Bootstrapper.cs
@@ -61,7 +61,9 @@ namespace Jarvis
             }
 
             // Show the root view.
-            DisplayRootViewFor<ShellViewModel>();
+            Dictionary<string, object> window_settings = new Dictionary<string, object>();
+            window_settings.Add("Visibility", System.Windows.Visibility.Hidden);
+            DisplayRootViewFor<ShellViewModel>(window_settings);
             Application?.MainWindow?.Hide();
 
             // Create the taskbar icon.

--- a/src/Jarvis/Views/ShellView.xaml
+++ b/src/Jarvis/Views/ShellView.xaml
@@ -11,7 +11,8 @@
         ResizeMode="NoResize"
         AllowsTransparency="True"
         ShowActivated="False"
-        Topmost="False" Visibility="Hidden" 
+        Topmost="False"
+        Visibility="Hidden"
         cal:Message.Attach="[Event Deactivated] = [Action OnDeactivated()]; [Event Closing] = [Action OnClose($eventArgs)]"
         WindowStyle="None">
 
@@ -69,7 +70,7 @@
                     </StackPanel>
                 </Grid>
                 <StackPanel Margin="11,0,11.4,11" Background="Transparent">
-                    <ContentControl x:Name="Result" />
+                    <ContentControl x:Name="Result" Focusable="False" />
                 </StackPanel>
             </StackPanel>
         </Border>


### PR DESCRIPTION
**Problem**

If jarvis starts, the main window is visibile for a second.

**Fix**

Add hidden visibility window settings to `DisplayRootViewFor`  to prevent flickering the window on startup.

```csharp
Dictionary<string, object> window_settings = new Dictionary<string, object>();
window_settings.Add("Visibility", System.Windows.Visibility.Hidden);
DisplayRootViewFor<ShellViewModel>(window_settings);
```