### PR TITLE
Move focus to main window of process if it's already running (using ProcessAddin)

### DIFF
--- a/src/Jarvis.Addin.Processes/Jarvis.Addin.Processes.csproj
+++ b/src/Jarvis.Addin.Processes/Jarvis.Addin.Processes.csproj
@@ -40,6 +40,11 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
          Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Jarvis.Addin.Processes/Jarvis.Addin.Processes.csproj
+++ b/src/Jarvis.Addin.Processes/Jarvis.Addin.Processes.csproj
@@ -32,6 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da">
+      <HintPath>..\packages\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
+    </Reference>
     <Reference Include="JetBrains.Annotations, Version=11.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325">
       <HintPath>..\packages\JetBrains.Annotations.11.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
     </Reference>
@@ -42,6 +45,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ProcessAddin.cs" />
     <Compile Include="ProcessProvider.cs" />
     <Compile Include="ProcessResult.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Jarvis.Addin.Processes/Jarvis.Addin.Processes.csproj
+++ b/src/Jarvis.Addin.Processes/Jarvis.Addin.Processes.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{AE5C446D-B1D3-4E98-941D-A751B80CA74F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Jarvis.Addin.Processes</RootNamespace>
+    <AssemblyName>Jarvis.Addin.Processes</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+         Other similar extension points exist, see Microsoft.Common.targets.
+    <Target Name="BeforeBuild">
+    </Target>
+    <Target Name="AfterBuild">
+    </Target>
+    -->
+</Project>

--- a/src/Jarvis.Addin.Processes/Jarvis.Addin.Processes.csproj
+++ b/src/Jarvis.Addin.Processes/Jarvis.Addin.Processes.csproj
@@ -35,12 +35,14 @@
     <Reference Include="JetBrains.Annotations, Version=11.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325">
       <HintPath>..\packages\JetBrains.Annotations.11.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
     </Reference>
+    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ProcessProvider.cs" />
     <Compile Include="ProcessResult.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Jarvis.Addin.Processes/Jarvis.Addin.Processes.csproj
+++ b/src/Jarvis.Addin.Processes/Jarvis.Addin.Processes.csproj
@@ -32,18 +32,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=11.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325">
+      <HintPath>..\packages\JetBrains.Annotations.11.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ProcessResult.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Jarvis.Core\Jarvis.Core.csproj">
+      <Project>{5826d320-9026-4be9-8c82-893c55b80871}</Project>
+      <Name>Jarvis.Core</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Jarvis.Addin.Processes/ProcessAddin.cs
+++ b/src/Jarvis.Addin.Processes/ProcessAddin.cs
@@ -1,0 +1,13 @@
+﻿using Autofac;
+using Jarvis.Core;
+
+namespace Jarvis.Addin.Processes
+{
+    public sealed class ProcessAddin : IAddin
+    {
+        public void Configure(ContainerBuilder builder)
+        {
+            builder.RegisterType<ProcessProvider>().As<IQueryProvider>().SingleInstance();
+        }
+    }
+}

--- a/src/Jarvis.Addin.Processes/ProcessProvider.cs
+++ b/src/Jarvis.Addin.Processes/ProcessProvider.cs
@@ -35,7 +35,8 @@ namespace Jarvis.Addin.Processes
             {
                 return (IEnumerable<IQueryResult>) Process.GetProcesses()
                     .Where(process => process.MainWindowTitle
-                                          .IndexOf(query.Raw, StringComparison.OrdinalIgnoreCase) >= 0)
+                                          .IndexOf(query.Raw, StringComparison.OrdinalIgnoreCase) >= 0 &&
+                                      process.Responding) // Ensure there is a GUI to display
                     .Select(process => (IQueryResult) new ProcessResult(
                         process.Id, process.MainWindowTitle, process.ProcessName,
                         LevenshteinScorer.Score(process.MainWindowTitle, query.Raw, false),

--- a/src/Jarvis.Addin.Processes/ProcessProvider.cs
+++ b/src/Jarvis.Addin.Processes/ProcessProvider.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Jarvis.Addin.Processes;
+using Jarvis.Core;
+using Jarvis.Core.Diagnostics;
+using Jarvis.Core.Interop;
+using Jarvis.Core.Scoring;
+using JetBrains.Annotations;
+
+namespace Jarvis.Addin.Processes
+{
+    [UsedImplicitly]
+    internal sealed class ProcessProvider : QueryProvider<ProcessResult>
+    {
+        private readonly IJarvisLog _log;
+
+        public ProcessProvider(IJarvisLog log)
+        {
+            _log = log;
+        }
+        
+        protected override Task<ImageSource> GetIconAsync(ProcessResult result)
+        {
+            return Task.FromResult(null as ImageSource);
+        }
+
+        public override Task<IEnumerable<IQueryResult>> QueryAsync(Query query)
+        {
+            return Task.Run(() =>
+            {
+                var results = Process.GetProcesses()
+                    .Where(process => process.MainWindowTitle.IndexOf(query.Raw, StringComparison.OrdinalIgnoreCase) >= 0)
+                    .Select(process => (IQueryResult) new ProcessResult(process.Id, process.MainWindowTitle, process.ProcessName, LevenshteinScorer.Score(process.MainWindowTitle, query.Raw, false), LevenshteinScorer.Score(process.MainWindowTitle, query.Raw)))
+                    .ToList();
+
+                return results.AsEnumerable();
+            });
+        }
+
+        protected override Task ExecuteAsync(ProcessResult result)
+        {
+            var process = Process.GetProcessById(result.ProcessId);
+            Win32.Window.SetForegroundWindow(process.MainWindowHandle);
+                        
+            var rect = new Win32.W32Rect();
+            Win32.Window.GetWindowRect(process.MainWindowHandle, ref rect);
+            if (rect.Top < 0 && rect.Right < 0 && rect.Bottom < 0 && rect.Left < 0) // Window is minimized
+            {
+                Win32.Window.ShowWindow(process.MainWindowHandle, 1);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Jarvis.Addin.Processes/ProcessProvider.cs
+++ b/src/Jarvis.Addin.Processes/ProcessProvider.cs
@@ -49,9 +49,7 @@ namespace Jarvis.Addin.Processes
             var process = Process.GetProcessById(result.ProcessId);
             Win32.Window.SetForegroundWindow(process.MainWindowHandle);
                         
-            var rect = new Win32.W32Rect();
-            Win32.Window.GetWindowRect(process.MainWindowHandle, ref rect);
-            if (rect.Top < 0 && rect.Right < 0 && rect.Bottom < 0 && rect.Left < 0) // Window is minimized
+            if (Win32.Window.IsIconic(process.MainWindowHandle)) // Window is minimized
             {
                 Win32.Window.ShowWindow(process.MainWindowHandle, 1);
             }

--- a/src/Jarvis.Addin.Processes/ProcessProvider.cs
+++ b/src/Jarvis.Addin.Processes/ProcessProvider.cs
@@ -33,12 +33,14 @@ namespace Jarvis.Addin.Processes
         {
             return Task.Run(() =>
             {
-                var results = Process.GetProcesses()
-                    .Where(process => process.MainWindowTitle.IndexOf(query.Raw, StringComparison.OrdinalIgnoreCase) >= 0)
-                    .Select(process => (IQueryResult) new ProcessResult(process.Id, process.MainWindowTitle, process.ProcessName, LevenshteinScorer.Score(process.MainWindowTitle, query.Raw, false), LevenshteinScorer.Score(process.MainWindowTitle, query.Raw)))
-                    .ToList();
-
-                return results.AsEnumerable();
+                return (IEnumerable<IQueryResult>) Process.GetProcesses()
+                    .Where(process => process.MainWindowTitle
+                                          .IndexOf(query.Raw, StringComparison.OrdinalIgnoreCase) >= 0)
+                    .Select(process => (IQueryResult) new ProcessResult(
+                        process.Id, process.MainWindowTitle, process.ProcessName,
+                        LevenshteinScorer.Score(process.MainWindowTitle, query.Raw, false),
+                        LevenshteinScorer.Score(process.MainWindowTitle, query.Raw)))
+                    .ToList(); // Make LINQ execute inside Task before returning
             });
         }
 

--- a/src/Jarvis.Addin.Processes/ProcessResult.cs
+++ b/src/Jarvis.Addin.Processes/ProcessResult.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Diagnostics;
+using Jarvis.Core;
+using JetBrains.Annotations;
+
+namespace Jarvis.Addin.Processes
+{
+    [UsedImplicitly]
+    [DebuggerDisplay("{" + nameof(Title) + ",nq}")]
+    internal struct ProcessResult : IQueryResult, IEquatable<ProcessResult>
+    {
+        public int ProcessId { get; }
+        public string Title { get; }
+        public string Description { get; }
+        public float Distance { get; }
+        public float Score { get; }
+        public QueryResultType Type => QueryResultType.Application;
+
+        public ProcessResult(int processId, string title, string description,
+            float distance, float score)
+        {
+            ProcessId = processId;
+            Title = title;
+            Description = description;
+            Distance = distance;
+            Score = score;
+        }
+
+        public bool Equals(IQueryResult obj)
+        {
+            return obj != null && obj.GetType() == GetType()
+                               && Equals((ProcessResult) obj);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj != null && (obj.GetType() == GetType()
+                                   && Equals((ProcessResult) obj));
+        }
+
+        public bool Equals(ProcessResult other)
+        {
+            return other.ProcessId.Equals(ProcessId);
+        }
+
+        public override int GetHashCode()
+        {
+            return ProcessId.GetHashCode();
+        }
+    }
+}

--- a/src/Jarvis.Addin.Processes/Properties/AssemblyInfo.cs
+++ b/src/Jarvis.Addin.Processes/Properties/AssemblyInfo.cs
@@ -1,17 +1,13 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using Jarvis.Addin.Processes;
+using Jarvis.Core;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Jarvis.Addin.Processes")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Jarvis.Addin.Processes")]
-[assembly: AssemblyCopyright("Copyright ©  2018")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
@@ -21,15 +17,5 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("AE5C446D-B1D3-4E98-941D-A751B80CA74F")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+// The addin definition.
+[assembly: Addin(typeof(ProcessAddin))]

--- a/src/Jarvis.Addin.Processes/Properties/AssemblyInfo.cs
+++ b/src/Jarvis.Addin.Processes/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Jarvis.Addin.Processes")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Jarvis.Addin.Processes")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("AE5C446D-B1D3-4E98-941D-A751B80CA74F")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Jarvis.Core/Interop/Win32.Window.cs
+++ b/src/Jarvis.Core/Interop/Win32.Window.cs
@@ -16,6 +16,12 @@ namespace Jarvis.Core.Interop
 
             [DllImport("user32.dll")]
             public static extern bool GetWindowRect(IntPtr hwnd, ref W32Rect rectangle);
+            
+            [DllImport("user32.dll")] 
+            public static extern bool SetForegroundWindow(IntPtr hwnd); 
+ 
+            [DllImport("user32.dll")] 
+            public static extern bool ShowWindow(IntPtr hwnd, int nCmdShow); 
         }
     }
 }

--- a/src/Jarvis.Core/Interop/Win32.Window.cs
+++ b/src/Jarvis.Core/Interop/Win32.Window.cs
@@ -21,7 +21,10 @@ namespace Jarvis.Core.Interop
             public static extern bool SetForegroundWindow(IntPtr hwnd); 
  
             [DllImport("user32.dll")] 
-            public static extern bool ShowWindow(IntPtr hwnd, int nCmdShow); 
+            public static extern bool ShowWindow(IntPtr hwnd, int nCmdShow);
+
+            [DllImport("user32.dll")]
+            public static extern bool IsIconic(IntPtr hwnd);
         }
     }
 }

--- a/src/Jarvis.sln
+++ b/src/Jarvis.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jarvis.Addin.Wikipedia", "J
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jarvis.Tests", "Jarvis.Tests\Jarvis.Tests.csproj", "{B3874102-B91F-408C-A32C-A1F8F8921376}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jarvis.Addin.Processes", "Jarvis.Addin.Processes\Jarvis.Addin.Processes.csproj", "{AE5C446D-B1D3-4E98-941D-A751B80CA74F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +49,10 @@ Global
 		{B3874102-B91F-408C-A32C-A1F8F8921376}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B3874102-B91F-408C-A32C-A1F8F8921376}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B3874102-B91F-408C-A32C-A1F8F8921376}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE5C446D-B1D3-4E98-941D-A751B80CA74F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE5C446D-B1D3-4E98-941D-A751B80CA74F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE5C446D-B1D3-4E98-941D-A751B80CA74F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE5C446D-B1D3-4E98-941D-A751B80CA74F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -55,6 +61,7 @@ Global
 		{6E2C9A93-08D3-42C8-9822-9C17D118E646} = {511CB402-AE1B-4E3B-BFA1-80E585EE3AB5}
 		{630865D0-C44B-41BD-AA6E-4697A4A12BD9} = {511CB402-AE1B-4E3B-BFA1-80E585EE3AB5}
 		{CBB05832-5634-4611-ADA1-E3793C5765D6} = {511CB402-AE1B-4E3B-BFA1-80E585EE3AB5}
+		{AE5C446D-B1D3-4E98-941D-A751B80CA74F} = {511CB402-AE1B-4E3B-BFA1-80E585EE3AB5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7AC5E44D-16BB-4EA9-97C7-0B74E46083C4}

--- a/src/Jarvis/Bootstrapper.cs
+++ b/src/Jarvis/Bootstrapper.cs
@@ -9,6 +9,7 @@ using Autofac;
 using Caliburn.Micro;
 using Jarvis.Addin.Files;
 using Jarvis.Addin.Google;
+using Jarvis.Addin.Processes;
 using Jarvis.Addin.Wikipedia;
 using Jarvis.Bootstrapping;
 using Jarvis.Core;
@@ -46,7 +47,8 @@ namespace Jarvis
             builder.RegisterModule(new AddinModule(
                 typeof(FileAddin).Assembly,
                 typeof(GoogleAddin).Assembly,
-                typeof(WikipediaAddin).Assembly));
+                typeof(WikipediaAddin).Assembly,
+                typeof(ProcessAddin).Assembly));
 
             // Build the container.
             _container = builder.Build();

--- a/src/Jarvis/Jarvis.csproj
+++ b/src/Jarvis/Jarvis.csproj
@@ -233,6 +233,10 @@
       <Project>{630865d0-c44b-41bd-aa6e-4697a4a12bd9}</Project>
       <Name>Jarvis.Addin.Google</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Jarvis.Addin.Processes\Jarvis.Addin.Processes.csproj">
+      <Project>{AE5C446D-B1D3-4E98-941D-A751B80CA74F}</Project>
+      <Name>Jarvis.Addin.Processes</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Jarvis.Addin.Wikipedia\Jarvis.Addin.Wikipedia.csproj">
       <Project>{cbb05832-5634-4611-ada1-e3793c5765d6}</Project>
       <Name>Jarvis.Addin.Wikipedia</Name>


### PR DESCRIPTION
After having difficulty getting #49 to work i propose this alternative solution. Using an addin to query the currently running processes and provide them as query results.

This still needs some work regarding UWP processes, as it currently includes the background processes of UWP apps.

This closes #38, #49