### PR TITLE
Offer to search Google when no search results are returned

### DIFF
--- a/src/Jarvis.Addin.Files/FileProvider.cs
+++ b/src/Jarvis.Addin.Files/FileProvider.cs
@@ -48,6 +48,11 @@ namespace Jarvis.Addin.Files
             return await _index.Find(query.Raw?.Trim(), CancellationToken.None).ConfigureAwait(false);
         }
 
+        protected override Task<IQueryResult> CreateFallbackResult(string query)
+        {
+            throw new NotImplementedException();
+        }
+
         protected override Task ExecuteAsync(FileResult result)
         {
             if (result.Path != null)

--- a/src/Jarvis.Addin.Google/GoogleProvider.cs
+++ b/src/Jarvis.Addin.Google/GoogleProvider.cs
@@ -70,7 +70,7 @@ namespace Jarvis.Addin.Google
 
                     return queryResults.Any()
                         ? queryResults.Select(x => GoogleResult.Create(query, x))
-                        : new[] { GoogleResult.Create(query, description: $"Search Google for '{query.Argument}'") };
+                        : new[] { await CreateFallbackResult(query.Argument) };
                 }
             }
             catch (Exception e)
@@ -79,6 +79,11 @@ namespace Jarvis.Addin.Google
             }
 
             return Enumerable.Empty<IQueryResult>();
+        }
+
+        protected override Task<IQueryResult> CreateFallbackResult(string query)
+        {
+            return Task.FromResult(GoogleResult.Create(new Query($"g {query}"), description: $"Search Google for '{query}'"));
         }
 
         protected override Task ExecuteAsync(GoogleResult result)

--- a/src/Jarvis.Addin.Wikipedia/WikipediaProvider.cs
+++ b/src/Jarvis.Addin.Wikipedia/WikipediaProvider.cs
@@ -77,13 +77,7 @@ namespace Jarvis.Addin.Wikipedia
 
                     if (!results.Any())
                     {
-                        var fallbackUrl = new Uri($"https://en.wikipedia.org/wiki/{Encode(query.Argument)}");
-                        return new[]
-                        {
-                            (IQueryResult)new WikipediaResult(
-                                fallbackUrl, $"Search Wikipedia for '{query.Argument}'",
-                                fallbackUrl.AbsoluteUri, 0, 0)
-                        };
+                        return new[] { await CreateFallbackResult(query.Argument) };
                     }
 
                     return results;
@@ -95,6 +89,14 @@ namespace Jarvis.Addin.Wikipedia
             }
 
             return Enumerable.Empty<IQueryResult>();
+        }
+
+        protected override Task<IQueryResult> CreateFallbackResult(string query)
+        {
+            var fallbackUrl = new Uri($"https://en.wikipedia.org/wiki/{Encode(query)}");
+            return Task.FromResult((IQueryResult)new WikipediaResult(
+                    fallbackUrl, $"Search Wikipedia for '{query}'",
+                    fallbackUrl.AbsoluteUri, 0, 0));
         }
 
         protected override Task ExecuteAsync(WikipediaResult result)

--- a/src/Jarvis.Core/IQueryProvider.cs
+++ b/src/Jarvis.Core/IQueryProvider.cs
@@ -17,6 +17,7 @@ namespace Jarvis.Core
 
         Task<ImageSource> GetIconAsync(IQueryResult result);
         Task<IEnumerable<IQueryResult>> QueryAsync(Query query);
+        Task<IQueryResult> CreateFallbackResult(string query);
         Task ExecuteAsync(IQueryResult result);
     }
 }

--- a/src/Jarvis.Core/QueryProvider.cs
+++ b/src/Jarvis.Core/QueryProvider.cs
@@ -33,8 +33,14 @@ namespace Jarvis.Core
             return ExecuteAsync((TResult)result);
         }
 
+        Task<IQueryResult> IQueryProvider.CreateFallbackResult(string query)
+        {
+            return CreateFallbackResult(query);
+        }
+
         protected abstract Task<ImageSource> GetIconAsync(TResult result);
         protected abstract Task ExecuteAsync(TResult result);
+        protected abstract Task<IQueryResult> CreateFallbackResult(string query);
 
         public abstract Task<IEnumerable<IQueryResult>> QueryAsync(Query query);
     }

--- a/src/Jarvis/Services/QueryProviderService.cs
+++ b/src/Jarvis/Services/QueryProviderService.cs
@@ -73,6 +73,13 @@ namespace Jarvis.Services
             });
 
             await Task.WhenAll(tasks);
+
+            if (!target.Any())
+            {
+                // Default to Google now, but may be set by user in Settings in future
+                var provider = GetProviders(new Query($"g {query.Raw}")).First();
+                target.Add(await provider.CreateFallbackResult(query.Raw));
+            }
         }
 
         public async Task Execute(IQueryResult result)


### PR DESCRIPTION
Adds a function on `IQueryProvider` to supply a "fallback result" which  supplies a generic search with the provider. This makes it possible to add a setting specifying a desired fallback provider in the user settings later.

This closes #8.